### PR TITLE
fix(rules): prevent false positive in DF062 (self-referencing ENV)

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -876,7 +876,7 @@ fn rule_from_platform_flag(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {
 }
 
 fn rule_env_self_reference(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {
-    let re = Regex::new(r"(\w+)=.*\$\{?(\w+)\}?").unwrap();
+    let re = Regex::new(r"(\w+)=\s*[\x22\x27]?\$\{?(\w+)\}?").unwrap();
     let mut findings = Vec::new();
     for i in instrs_of(instrs, "ENV") {
         for cap in re.captures_iter(&i.arguments) {

--- a/tests/rules_test.rs
+++ b/tests/rules_test.rs
@@ -262,3 +262,29 @@ fn df030_clear_with_no_cache() {
     let df = "FROM python:3.12\nRUN pip install --no-cache-dir flask\nCMD [\"python\", \"app.py\"]\n";
     assert!(no_rule(&lint(df), "DF030"));
 }
+
+// ─── DF062: ENV self-reference ───────────────────────────────────────────────
+
+#[test]
+fn df062_fires_on_direct_self_reference() {
+    let df = "FROM alpine:3.19\nENV MY_VAR=$MY_VAR\n";
+    assert!(has_rule(&lint(df), "DF062"));
+}
+
+#[test]
+fn df062_fires_on_quoted_self_reference() {
+    let df = "FROM alpine:3.19\nENV PATH=\"$PATH\"\n";
+    assert!(has_rule(&lint(df), "DF062"));
+}
+
+#[test]
+fn df062_clear_on_path_append() {
+    let df = "FROM python:3.13-slim\nENV VENV=/opt/venv/bin\nENV PATH=\"$VENV:$PATH\"\n";
+    assert!(no_rule(&lint(df), "DF062"));
+}
+
+#[test]
+fn df062_clear_on_normal_assignment() {
+    let df = "FROM alpine:3.19\nENV FOO=bar\nENV BAZ=$FOO\n";
+    assert!(no_rule(&lint(df), "DF062"));
+}


### PR DESCRIPTION
Fixes #6

Added a couple tests to validate it. Works for real cases but now safely ignores situations like:

```
ENV PATH="/opt/venv/bin:$PATH"
```
or 
```
ENV VENV_PATH="/opt/venv/bin"
ENV PATH="$VENV_PATH:$PATH"
```