### PR TITLE
fix(rules): prevent false positive in DF006 (add remote)

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -222,9 +222,16 @@ fn rule_add_instead_of_copy(instrs: &[Instruction], _raw: &str) -> Vec<Finding> 
     instrs_of(instrs, "ADD")
         .into_iter()
         .filter(|i| {
-            let args = &i.arguments;
-            !args.contains("http://") && !args.contains("https://")
-                && !args.ends_with(".tar.gz") && !args.ends_with(".tgz")
+            let args: Vec<&str> = i.arguments.split_whitespace().collect();
+            if args.is_empty() { return false; }
+            
+            let source = args[0];
+            let is_url = source.contains("://");
+            let is_archive = source.ends_with(".tar.gz") 
+                || source.ends_with(".tgz") 
+                || source.ends_with(".tar.xz") 
+                || source.ends_with(".tar");
+            !is_url && !is_archive
         })
         .map(|i| Finding {
             rule: "DF006",

--- a/tests/rules_test.rs
+++ b/tests/rules_test.rs
@@ -101,10 +101,27 @@ fn df004_clear_when_cleanup_present() {
 }
 
 // ─── DF006: ADD instead of COPY ─────────────────────────────────────────────
-
 #[test]
 fn df006_fires_on_local_add() {
     let df = "FROM alpine:3.19\nADD ./config /app/config\n";
+    assert!(has_rule(&lint(df), "DF006"));
+}
+
+#[test]
+fn df006_clear_on_local_archive_extraction() {
+    let df = "FROM alpine:3.19\nADD ND_rejected_me0102.tgz /\n";
+    assert!(no_rule(&lint(df), "DF006"));
+}
+
+#[test]
+fn df006_clear_on_different_archive_formats() {
+    let df = "FROM alpine:3.19\nADD bundle.tar.gz /app/\nADD data.tar.xz /data/\n";
+    assert!(no_rule(&lint(df), "DF006"));
+}
+
+#[test]
+fn df006_fires_on_local_file_to_root() {
+    let df = "FROM alpine:3.19\nADD id_rsa.pub /\n";
     assert!(has_rule(&lint(df), "DF006"));
 }
 


### PR DESCRIPTION
Fixes #5

As reported by Issue #5 

This fixes the behaviour when using ADD for:

- clear when adding local compressed files
- clear when adding remote 

Updated tests to reflect the change.