### PR TITLE
fix: don't terminate RUN continuation at embedded comment lines (DF004 false positive)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,6 +20,12 @@ pub fn parse(content: &str) -> Vec<Instruction> {
 
         // If we're inside a continuation, collect
         if let Some(ref instr) = pending_instr.clone() {
+            // Docker strips comment lines and empty lines inside continuations
+            // (the continuation keeps going), so they must not terminate the
+            // instruction even though they don't end with a backslash.
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
             // Strip trailing backslash
             let continued = if trimmed.ends_with('\\') {
                 &trimmed[..trimmed.len() - 1]
@@ -111,5 +117,21 @@ mod tests {
         let instrs = parse(df);
         assert_eq!(instrs.len(), 1);
         assert_eq!(instrs[0].instruction, "RUN");
+    }
+
+    #[test]
+    fn test_comment_inside_continuation() {
+        let df = "RUN apt-get install \\\n    curl \\\n    # comment line\n    wget && \\\n    apt-get clean\n";
+        let instrs = parse(df);
+        assert_eq!(instrs.len(), 1);
+        assert_eq!(instrs[0].arguments, "apt-get install curl wget && apt-get clean");
+    }
+
+    #[test]
+    fn test_empty_line_inside_continuation() {
+        let df = "RUN apt-get install \\\n\n    curl\n";
+        let instrs = parse(df);
+        assert_eq!(instrs.len(), 1);
+        assert_eq!(instrs[0].arguments, "apt-get install curl");
     }
 }

--- a/tests/rules_test.rs
+++ b/tests/rules_test.rs
@@ -100,6 +100,14 @@ fn df004_clear_when_cleanup_present() {
     assert!(no_rule(&lint(df), "DF004"));
 }
 
+#[test]
+fn df004_clear_with_comment_inside_continuation() {
+    // Docker strips comment lines inside continuations, so the trailing
+    // cleanup still belongs to the same RUN (issue #11).
+    let df = "FROM debian:bookworm-slim\nRUN apt-get update && \\\n    apt-get install -y --no-install-recommends \\\n        curl \\\n        # embedded comment\n        ca-certificates && \\\n    apt-get clean && \\\n    rm -rf /var/lib/apt/lists/*\nCMD [\"true\"]\n";
+    assert!(no_rule(&lint(df), "DF004"));
+}
+
 // ─── DF006: ADD instead of COPY ─────────────────────────────────────────────
 #[test]
 fn df006_fires_on_local_add() {


### PR DESCRIPTION
Fixes #11.

## Problem

A comment line embedded inside a `RUN` line continuation (legal Dockerfile syntax — Docker's parser strips these) terminated the instruction early in `parser::parse`: the comment line doesn't end with `\`, so the continuation-collection branch treated it as the final line. Everything after the comment (e.g. a trailing `apt-get clean && rm -rf /var/lib/apt/lists/*`) was cut off from the instruction's `arguments`, producing false positives like DF004 on Dockerfiles that comment groups of packages inside a long install list.

## Fix

In the continuation branch, skip comment lines and empty lines without terminating the instruction — matching Docker's own parsing (BuildKit strips comments inside continuations; empty continuation lines are tolerated with a deprecation warning).

## Tests

- `parser::tests::test_comment_inside_continuation` — asserts the joined `arguments` includes everything after the embedded comment.
- `parser::tests::test_empty_line_inside_continuation` — same for a blank line.
- `rules_test::df004_clear_with_comment_inside_continuation` — the exact repro from #11 no longer fires DF004.

Full `cargo test` suite passes (run on linux/arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
