### PR TITLE
Add a `pre-commit` hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: droast
+  name: droast
+  description: Roast Dockerfiles for security, layer hygiene, and best-practice violations.
+  entry: droast
+  language: rust
+  files: '(^|/)((Dockerfile|Containerfile)(\.[^/]+)?|[^/]+\.Dockerfile)$'
+  exclude: '\.dockerignore$'

--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ roast Dockerfiles before they even reach CI, via [pre-commit](https://pre-commit
 
 ```yaml
 - repo: https://github.com/immanuwell/dockerfile-roast
-  rev: 1.4.2
+  rev: 1.4.4
   hooks:
     - id: droast
 ```
 
-the hook runs on `Dockerfile`, `Dockerfile.*`, `*.Dockerfile`, `Containerfile` and `Containerfile.*` — the same names droast discovers on its own. pass flags through `args` as usual:
+the hook runs on `Dockerfile`, `Dockerfile.*`, `*.Dockerfile`, `Containerfile`, and `Containerfile.*`, while excluding Dockerfile-specific `.dockerignore` files. pass flags through `args` as usual:
 
 ```yaml
     - id: droast

--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ example with options:
 
 <!-- droast:action-version:end -->
 
+## pre-commit
+
+roast Dockerfiles before they even reach CI, via [pre-commit](https://pre-commit.com):
+
+```yaml
+- repo: https://github.com/immanuwell/dockerfile-roast
+  rev: 1.4.2
+  hooks:
+    - id: droast
+```
+
+the hook runs on `Dockerfile`, `Dockerfile.*`, `*.Dockerfile`, `Containerfile` and `Containerfile.*` — the same names droast discovers on its own. pass flags through `args` as usual:
+
+```yaml
+    - id: droast
+      args: [--min-severity, warning, --skip, DF012]
+```
+
 ## docker
 
 pull from ghcr and use immediately, no install needed:


### PR DESCRIPTION
Expose droast as a [pre-commit](https://pre-commit.com/) hook. 
This is great to catch error before ci and fit's well tools that are fast

I made file matching mirrors droast's own discovery names with *.dockerignore excluded so per-Dockerfile ignore files are not linted as Dockerfiles.

If you don't want to have to support this yourself, I can also setup a mirror using https://github.com/pre-commit/pre-commit-mirror-maker but that's a little bit more work for me

You can test it using `pre-commit try-repo /path/to/dockerfile-roast droast --files path/to/Dockerfile`. I tested it myself that way on a few projects using dockerfiles