### PR TITLE
fix: avoid DF021 false positives for sha256sum

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1821,7 +1821,7 @@ fn rule_hardcoded_secrets(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {
 }
 
 fn rule_curl_pipe_sh(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {
-    let re = Regex::new(r"(curl|wget)[^|]*\|\s*(bash|sh|ash|zsh|fish)").unwrap();
+    let re = Regex::new(r"(curl|wget)[^|]*\|\s*(bash|sh|ash|zsh|fish)\b").unwrap();
     instrs_of(instrs, "RUN")
         .into_iter()
         .filter(|i| re.is_match(&i.arguments))

--- a/tests/rules_test.rs
+++ b/tests/rules_test.rs
@@ -305,6 +305,12 @@ fn df021_fires_on_wget_pipe_bash() {
     assert!(has_rule(&lint(df), "DF021"));
 }
 
+#[test]
+fn df021_clear_when_checksum_output_is_piped_to_sha256sum() {
+    let df = "FROM ubuntu:24.04\nRUN curl -fsSLo /tmp/tool https://example.com/tool \\\n+        && printf '%s  %s\\n' \"$TOOL_SHA256\" /tmp/tool | sha256sum -c -\n";
+    assert!(no_rule(&lint(df), "DF021"));
+}
+
 // ─── DF025: shell form CMD ───────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- require a word boundary after DF021 shell alternatives
- add a regression test for `printf ... | sha256sum -c -` after a download
- preserve the existing positive `curl | sh` and `wget | bash` cases

Closes #28.

## Verification

- `cargo test --locked df021_ -- --nocapture` (3 passed)
- `cargo test --locked --test rules_test` (all rule tests passed)
- `git diff --check`

On Windows, the repository-wide `cargo test --locked` still has the pre-existing path-separator-sensitive `config::tests::path_overrides_apply_in_order` failure; this change does not touch configuration code.