### PR TITLE
fix: honor SHELL pipefail in DF057

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,4 +1,6 @@
-use crate::parser::{parse_document, DiagnosticSeverity, Instruction, SourceSpan};
+use crate::parser::{
+    parse_document, DiagnosticSeverity, Instruction, InstructionForm, SourceSpan,
+};
 use regex::Regex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -2249,35 +2251,56 @@ fn rule_untrusted_registry(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {
 }
 
 fn rule_pipefail_missing(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {
-    instrs_of(instrs, "RUN")
-        .into_iter()
-        .filter(|i| {
-            let a = &i.arguments;
-            // has a pipe that isn't curl|sh (that's covered separately) and isn't pipefail already set
-            a.contains(" | ")
-                && !a.contains("pipefail")
-                && !a.contains("set -o pipefail")
-                && !a.contains("set -eo pipefail")
-                && !a.contains("set -euo pipefail")
-                // only flag if it's not a trivial pipe to tee/grep/wc for log filtering
-                && !a.trim_start().starts_with("set ")
-        })
-        .map(|i| Finding {
-            column: 0,
-            end_line: 0,
-            end_column: 0,
-            rule: "DF057".into(),
-            severity: Severity::Warning,
-            line: i.line,
-            message:
-                "RUN with pipe but no pipefail — failed commands in the pipe are silently ignored"
-                    .to_string(),
-            roast: "A pipe in RUN without `set -o pipefail`. If the left side of that pipe fails, \
-                    bash shrugs and moves on. The exit code is whatever the last command returns. \
-                    Add `set -o pipefail` at the start of the RUN."
-                .to_string(),
-        })
-        .collect()
+    let mut shell_has_pipefail = false;
+    let mut findings = Vec::new();
+
+    for instruction in instrs {
+        match instruction.instruction.as_str() {
+            "FROM" => shell_has_pipefail = false,
+            "SHELL" => {
+                shell_has_pipefail = match &instruction.form {
+                    InstructionForm::Json(arguments) => {
+                        arguments
+                            .windows(2)
+                            .any(|pair| pair[0] == "-o" && pair[1] == "pipefail")
+                            || arguments.iter().any(|argument| argument == "-opipefail")
+                    }
+                    _ => false,
+                };
+            }
+            "RUN" => {
+                let a = &instruction.arguments;
+                // has a pipe that isn't curl|sh (that's covered separately) and isn't pipefail already set
+                if a.contains(" | ")
+                    && !shell_has_pipefail
+                    && !a.contains("pipefail")
+                    && !a.contains("set -o pipefail")
+                    && !a.contains("set -eo pipefail")
+                    && !a.contains("set -euo pipefail")
+                    // only flag if it's not a trivial pipe to tee/grep/wc for log filtering
+                    && !a.trim_start().starts_with("set ")
+                {
+                    findings.push(Finding {
+                        column: 0,
+                        end_line: 0,
+                        end_column: 0,
+                        rule: "DF057".into(),
+                        severity: Severity::Warning,
+                        line: instruction.line,
+                        message: "RUN with pipe but no pipefail — failed commands in the pipe are silently ignored"
+                            .to_string(),
+                        roast: "A pipe in RUN without `set -o pipefail`. If the left side of that pipe fails, \
+                                bash shrugs and moves on. The exit code is whatever the last command returns. \
+                                Add `set -o pipefail` at the start of the RUN."
+                            .to_string(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    findings
 }
 
 fn rule_wget_and_curl(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {

--- a/tests/rules_test.rs
+++ b/tests/rules_test.rs
@@ -1050,6 +1050,34 @@ fn df057_clear_on_pipe_with_pipefail() {
     assert!(no_rule(&lint(df), "DF057"));
 }
 
+#[test]
+fn df057_clear_when_shell_instruction_enables_pipefail() {
+    let df = "FROM ubuntu:24.04\nSHELL [\"/bin/bash\", \"-o\", \"pipefail\", \"-c\"]\nRUN cat /etc/os-release | grep ID\n";
+    assert!(no_rule(&lint(df), "DF057"));
+}
+
+#[test]
+fn df057_shell_pipefail_resets_at_next_stage() {
+    let df = "FROM ubuntu:24.04 AS build\nSHELL [\"/bin/bash\", \"-o\", \"pipefail\", \"-c\"]\nRUN cat /etc/os-release | grep ID\nFROM ubuntu:24.04\nRUN cat /etc/os-release | grep ID\n";
+    let findings: Vec<_> = lint(df)
+        .into_iter()
+        .filter(|finding| finding.rule == "DF057")
+        .collect();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].line, 5);
+}
+
+#[test]
+fn df057_later_shell_without_pipefail_overrides_prior_shell() {
+    let df = "FROM ubuntu:24.04\nSHELL [\"/bin/bash\", \"-o\", \"pipefail\", \"-c\"]\nRUN cat /etc/os-release | grep ID\nSHELL [\"/bin/sh\", \"-c\"]\nRUN cat /etc/os-release | grep ID\n";
+    let findings: Vec<_> = lint(df)
+        .into_iter()
+        .filter(|finding| finding.rule == "DF057")
+        .collect();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].line, 5);
+}
+
 // ─── DF058: wget and curl both used ──────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- track the effective `SHELL` while evaluating DF057
- treat JSON-form `-o pipefail` / `-opipefail` as enabling pipe failure propagation
- reset shell state at `FROM` and replace it at later `SHELL` instructions
- add regressions for suppression, stage reset, and shell replacement

Closes #30.

## Verification

- `cargo test --locked df057_ -- --nocapture` (5 passed)
- `cargo test --locked --test rules_test` (210 passed)
- `git diff --check`

## Existing Windows baseline

A full `cargo test --locked` run on Windows still has the pre-existing `config::tests::path_overrides_apply_in_order` path-separator failure; this change is confined to DF057 and its rule tests.