### PR TITLE
fix: allow native non-final build stages

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1915,9 +1915,25 @@ fn rule_useless_commands(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {
 }
 
 fn rule_from_platform_flag(instrs: &[Instruction], _raw: &str) -> Vec<Finding> {
-    instrs_of(instrs, "FROM")
+    let froms = instrs_of(instrs, "FROM");
+    let final_stage = froms.len().saturating_sub(1);
+
+    froms
         .into_iter()
-        .filter(|i| i.arguments.contains("--platform"))
+        .enumerate()
+        .filter(|(index, instruction)| {
+            let has_platform_flag = instruction
+                .flags
+                .iter()
+                .any(|flag| flag.name.eq_ignore_ascii_case("platform"));
+            let is_native_builder = *index < final_stage
+                && instruction.flags.iter().any(|flag| {
+                    flag.name.eq_ignore_ascii_case("platform")
+                        && matches!(flag.value.as_deref(), Some("$BUILDPLATFORM" | "${BUILDPLATFORM}"))
+                });
+            has_platform_flag && !is_native_builder
+        })
+        .map(|(_, i)| i)
         .map(|i| Finding {
             column: 0,
             end_line: 0,

--- a/tests/rules_test.rs
+++ b/tests/rules_test.rs
@@ -1158,6 +1158,24 @@ fn df061_clear_without_platform_flag() {
     assert!(no_rule(&lint(df), "DF061"));
 }
 
+#[test]
+fn df061_clear_for_native_build_stage() {
+    let df = "FROM --platform=$BUILDPLATFORM node:22 AS builder\nRUN npm run build\nFROM nginx:1.27\nCOPY --from=builder /app/dist /usr/share/nginx/html\n";
+    assert!(no_rule(&lint(df), "DF061"));
+}
+
+#[test]
+fn df061_clear_for_braced_native_build_stage() {
+    let df = "FROM --platform=${BUILDPLATFORM} node:22 AS builder\nRUN npm run build\nFROM nginx:1.27\nCOPY --from=builder /app/dist /usr/share/nginx/html\n";
+    assert!(no_rule(&lint(df), "DF061"));
+}
+
+#[test]
+fn df061_fires_when_final_stage_uses_buildplatform() {
+    let df = "FROM alpine:3.19 AS helper\nRUN echo helper\nFROM --platform=$BUILDPLATFORM alpine:3.19\nCMD [\"/bin/sh\"]\n";
+    assert!(has_rule(&lint(df), "DF061"));
+}
+
 // ─── DF062: ENV self-reference ────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- exempt non-final builder stages that use BUILDPLATFORM from DF061
- keep warning for literal platform pins and final stages using BUILDPLATFORM
- cover unbraced and braced BuildKit variables with focused regression tests

## Why

BUILDPLATFORM is the standard way to run a builder stage natively while a later runtime stage retains Docker's target-platform default. DF061 currently describes that pattern as forcing the deployed image architecture, which is not true for a non-final build stage.

Fixes #32.

## Verification

- cargo test df061: 5 passed
- cargo test --test rules_test: 215 passed
- Bifrost's real multi-stage client Dockerfile no longer reports DF061
- a final FROM --platform=$BUILDPLATFORM regression fixture still reports DF061